### PR TITLE
Date format and week/month names i18n

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,10 +10,6 @@ const ONE_DAY_MS = 86400000,
     ONE_MINUTE_MS = 60000,
     ONE_HOUR_MS = 3600000,
     IDLE_TIMEOUT_SECS = 30,
-    DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
-    MONTH_NAMES = ["December", "January", "February", "March",
-                  "April", "May", "June", "July", "August",
-                  "September", "October", "November"],
     WEEK_WORD = "Week",
     PAST_7_DAYS_TEXT = "Past 7 Days",
     STORAGE = browser.storage.local,
@@ -178,8 +174,9 @@ function get_week_number(dayNumber) {
 };
 
 function get_day_header_text(date) {
-    return DAY_NAMES[date.getDay()] + "   " +
-        (date.getMonth() + 1) + "/" + date.getDate();
+    let options = {weekday: 'long', month: 'numeric', day: 'numeric'};
+    let dtf = new Intl.DateTimeFormat(undefined, options);
+    return dtf.format(date);
 };
 
 function get_date_with_offset(aOffset, aDateNow) {

--- a/src/new-day.js
+++ b/src/new-day.js
@@ -9,23 +9,18 @@
 function get_week_header_text(weekNum) {
     let from = new Date((weekNum + 1) * ONE_DAY_MS),
         to = new Date(from.getTime() + (6 * ONE_DAY_MS)),
-        fromMonth = from.getMonth() + 1,
-        fromDate = from.getDate(),
-        toMonth = to.getMonth() + 1,
         toDate = to.getDate();
 
-    return WEEK_WORD + " " + fromMonth + "/" + fromDate + " - " + toMonth + "/" + toDate;
+    let dtf = new Intl.DateTimeFormat(undefined, {month: 'numeric', day: 'numeric'});
+    return WEEK_WORD + " " + dtf.format(from) + " - " + dtf.format(to);
 };
 
 function get_past7days_header_text(num) {
     let from = new Date((num - 6) * ONE_DAY_MS), // a week ago
         to = new Date(num * ONE_DAY_MS), // yesterday
-        fromMonth = from.getMonth() + 1,
-        fromDate = from.getDate(),
-        toMonth = to.getMonth() + 1,
         toDate = to.getDate();
-
-    return PAST_7_DAYS_TEXT + "   " + fromMonth + "/" + fromDate + " - " + toMonth + "/" + toDate;
+    let dtf = new Intl.DateTimeFormat(undefined, {month: 'numeric', day: 'numeric'});
+    return PAST_7_DAYS_TEXT + "   " + dtf.format(from) + " - " + dtf.format(to);
 };
 
 function combine_data_from_days(sourceArray) {
@@ -67,7 +62,8 @@ function make_month_summ(monthNum, days) {
     let daysSubset = days.filter((day) => day && day.monthNum && day.monthNum === monthNum),
         summ = combine_data_from_days(daysSubset);
 
-    summ.headerText = MONTH_NAMES[monthNum % 12];
+    let dtf = new Intl.DateTimeFormat(undefined, {month: 'long'});
+    summ.headerText = dtf.format(new Date(2000, monthNum - 1));
     summ.monthNum = monthNum;
     return summ;
 };


### PR DESCRIPTION
Note: it only affects new data, because table headers are generated and
persisted while recording. Not cleaning up the now-unnecessary +1 for
monthNum because it might mess up new-month detection at upgrade time.