### PR TITLE
Disable logging for incognito tabs

### DIFF
--- a/src/ticker-timer-modes.js
+++ b/src/ticker-timer-modes.js
@@ -37,27 +37,31 @@ function set_listeners_for_timer_mode(mode) {
     }
 };
 
-async function get_current_url_default() {
-    // returns a promise that resolves to the url of the active window/tab
+async function get_current_url_internal(mode) {
     try {
-        let tabs = await browser.tabs.query({currentWindow: true, active: true});
-        return new URL(tabs[0].url);
-
+        let tabs = await browser.tabs.query({currentWindow: true, active: true}),
+            tab = tabs[0];
+        if (tab.incognito) {
+            // visual confirmation ("we are not logging")
+            // (also, popup and statistics page have bugs in incognito mode)
+            browser.browserAction.disable(tab.id);
+            // override global badge color/text for this tab
+            browser.browserAction.setBadgeText({ text: "", tabId: tab.id });
+            // special incognito url (time not logged)
+            return new URL("http://incognito.o3xr2485dmmdi78177v7c33wtu7315.net/");
+        } else if (mode === 'B') {
+            // special blue-mode url
+            return new URL("http://o3xr2485dmmdi78177v7c33wtu7315.net/");
+        } else {
+            return new URL(tab.url);
+        }
     } catch (e) { console.error(e); }
-};
-
-function get_current_url_blue_mode() {
-    // return a promise to match the async get_current_url_default
-    let url = new URL("http://o3xr2485dmmdi78177v7c33wtu7315.net/");
-    return Promise.resolve(url);
 };
 
 var get_current_url;
 
 function set_current_url_function(mode) {
-    get_current_url = mode === 'B'
-        ? get_current_url_blue_mode
-        : get_current_url_default;
+    get_current_url = get_current_url_internal.bind(undefined, mode);
 };
 
 // updates the time shown in the button badge ticker

--- a/src/tracking-events.js
+++ b/src/tracking-events.js
@@ -148,6 +148,10 @@ function is_clockable_protocol(aProt) {
     return aProt === 'http:' || aProt === 'https:';
 };
 
+function is_incognito_domain(aDomain) {
+    return aDomain === "incognito.o3xr2485dmmdi78177v7c33wtu7315.net";
+};
+
 async function pre_clock_on_2(aUrl) {
     // Maybe starts a new day, updates the ticker, and maybe clocks on.
     // aUrl parameter is used for testing new day change.
@@ -171,7 +175,8 @@ async function pre_clock_on_2(aUrl) {
         // Only clock on if the domain has a clockable url protocol
         // (http/https) and it is not in the whitelist.
         if (is_clockable_protocol(url.protocol) &&
-            !fromStorage.oWhitelistArray.includes(domain)) {
+            !fromStorage.oWhitelistArray.includes(domain) &&
+            !is_incognito_domain(domain)) {
 
             let seconds = fromStorage[domain] || 0;
             update_ticker(seconds, fromStorage.totalSecs);


### PR DESCRIPTION
Firefox does currently not support doing this via manifest.json:
https://bugzilla.mozilla.org/show_bug.cgi?id=1345474

Looks like it will remain like that for a while:
https://bugzilla.mozilla.org/show_bug.cgi?id=1380809
status-firefox57: wontfix