### PR TITLE
Update options.html with note for macOS users

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -36,7 +36,7 @@
       </p>
 
       <h4>Reminder Notifications</h4>
-      <p class="notice"><em>NOTE: macOS users need to Allow notifications for Firefox under System Settings → Notifications for this feature to work</em></p>
+      <p class="notice"><em>NOTE: macOS users need to Allow notifications for Firefox under System Settings → Notifications for this feature to work.</em></p>
       <p>Transient notifications that indicate the amount of time spent on the web so far today.</p>
       <p>
       <label><input type="radio" value="notificationsOn" id="notificationsOn" name="showRemindersPref" checked="true">On</label><br>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -36,6 +36,7 @@
       </p>
 
       <h4>Reminder Notifications</h4>
+      <p class="notice"><em>NOTE: macOS users need to Allow notifications for Firefox under System Settings → Notifications for this feature to work</em></p>
       <p>Transient notifications that indicate the amount of time spent on the web so far today.</p>
       <p>
       <label><input type="radio" value="notificationsOn" id="notificationsOn" name="showRemindersPref" checked="true">On</label><br>


### PR DESCRIPTION
For reminders to appear for macOS users they need to allow Firefox to send notifications, this permission appears to be disabled by default on macOS and Firefox does not remind the user of this when the add-on is installed.

This can cause some confusion, because Firefox will notify the user that the add-on will have (browser-level) notification permissions on installation, but Firefox will not notify the user if it does not have system permissions for notifications on macOS (as is the case by default).

I updated options.html with a note about this to prevent confusion for macOS users. I think it might be possible to update options.html from options.js based on OS when the page is opened so that this note is only shown to macOS users, but this commit does not include that.

I also submitted an issue #25 which suggests possibly updating the longer add-on description with a similar note. I believe that can only be done by the add-on publisher, only the short description can be changed in manifest.json and it wouldn't be a good place for a note like that.